### PR TITLE
Add supporting for "halting" events

### DIFF
--- a/cmd/webhookd-generate-hook/main.go
+++ b/cmd/webhookd-generate-hook/main.go
@@ -47,7 +47,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Usage:\n\t %s [options]\n", os.Args[0])
 		flag.PrintDefaults()
 	}
-	
+
 	flag.Parse()
 
 	fmt.Println(RandomString(*length))

--- a/cmd/webhookd/main.go
+++ b/cmd/webhookd/main.go
@@ -22,7 +22,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Usage:\n\t %s [options]\n", os.Args[0])
 		fs.PrintDefaults()
 	}
-	
+
 	flagset.Parse(fs)
 
 	err := flagset.SetFlagsFromEnvVarsWithFeedback(fs, "WEBHOOKD", false)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -310,8 +310,15 @@ func (d *WebhookDaemon) HandlerFuncWithLogger(logger *log.Logger) (http.HandlerF
 				err = d.Dispatch(ctx, body)
 
 				if err != nil {
-					logger.Printf("Dispatch step (%T) at offset %d failed, %v", d, idx, err)
-					ch <- err
+
+					switch err.Code {
+					case webhookd.UnhandledEvent, webhookd.HaltEvent:
+						logger.Printf("Dispatch step (%T) at offset %d returned non-fatal error and exiting, %v", d, idx, err)
+						return
+					default:
+						logger.Printf("Dispatch step (%T) at offset %d failed, %v", d, idx, err)
+						ch <- err
+					}
 				}
 
 			}(idx, d, body)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -248,13 +248,17 @@ func (d *WebhookDaemon) HandlerFuncWithLogger(logger *log.Logger) (http.HandlerF
 		// not an error, for example when github sends a ping message
 		// (20190212/thisisaaronland)
 
-		if err != nil && err.Code == -1 {
-			return
-		}
-
 		if err != nil {
-			http.Error(rsp, err.Error(), err.Code)
-			return
+
+			switch err.Code {
+			case webhookd.UnhandledEvent, webhookd.HaltEvent:
+				logger.Printf("Receiver step (%T)  returned non-fatal error and exiting, %v", rcvr, err)
+				return
+			default:
+				logger.Printf("Receiver step (%T) failed, %v", rcvr, err)
+				http.Error(rsp, err.Error(), err.Code)
+				return
+			}
 		}
 
 		tb = time.Since(ta)
@@ -263,13 +267,21 @@ func (d *WebhookDaemon) HandlerFuncWithLogger(logger *log.Logger) (http.HandlerF
 
 		ta = time.Now()
 
-		for _, step := range wh.Transformations() {
+		for idx, step := range wh.Transformations() {
 
 			body, err = step.Transform(ctx, body)
 
 			if err != nil {
-				http.Error(rsp, err.Error(), err.Code)
-				return
+
+				switch err.Code {
+				case webhookd.UnhandledEvent, webhookd.HaltEvent:
+					logger.Printf("Transformation step (%T) at offset %d returned non-fatal error and exiting, %v", step, idx, err)
+					return
+				default:
+					logger.Printf("Transformation step (%T) at offset %d failed, %v", step, idx, err)
+					http.Error(rsp, err.Error(), err.Code)
+					return
+				}
 			}
 
 			// check to see if there is anything left the transformation
@@ -287,22 +299,22 @@ func (d *WebhookDaemon) HandlerFuncWithLogger(logger *log.Logger) (http.HandlerF
 		wg := new(sync.WaitGroup)
 		ch := make(chan *webhookd.WebhookError)
 
-		for _, d := range wh.Dispatchers() {
+		for idx, d := range wh.Dispatchers() {
 
 			wg.Add(1)
 
-			go func(d webhookd.WebhookDispatcher, body []byte) {
+			go func(idx int, d webhookd.WebhookDispatcher, body []byte) {
 
 				defer wg.Done()
 
 				err = d.Dispatch(ctx, body)
 
 				if err != nil {
-					logger.Printf("FAILED TO DISPATCH W/ %T, %v\n", d, err)
+					logger.Printf("Dispatch step (%T) at offset %d failed, %v", d, idx, err)
 					ch <- err
 				}
 
-			}(d, body)
+			}(idx, d, body)
 		}
 
 		// https://github.com/whosonfirst/go-webhookd/issues/14

--- a/dispatcher/log.go
+++ b/dispatcher/log.go
@@ -25,7 +25,7 @@ type LogDispatcher struct {
 
 // NewLogDispatcher returns a new `LogDispatcher` instance configured by 'uri' in the form of:
 //
-// 	log://
+//	log://
 //
 // Messasges are dispatched to the default `log.Default()` instance.
 func NewLogDispatcher(ctx context.Context, uri string) (webhookd.WebhookDispatcher, error) {

--- a/error.go
+++ b/error.go
@@ -4,6 +4,10 @@ import (
 	"fmt"
 )
 
+const UnhandledEvent int = -1
+
+const HaltEvent int = -2
+
 // WebhookError implements the `error` interface for wrapping webhookd error codes and messages.
 type WebhookError struct {
 	error

--- a/error.go
+++ b/error.go
@@ -21,3 +21,8 @@ type WebhookError struct {
 func (e WebhookError) Error() string {
 	return fmt.Sprintf("%d %s", e.Code, e.Message)
 }
+
+// String returns a string representation of 'e'.
+func (e WebhookError) String() string {
+	return e.Error()
+}

--- a/receiver/insecure.go
+++ b/receiver/insecure.go
@@ -24,7 +24,7 @@ type InsecureReceiver struct {
 
 // NewInsecureReceiver returns a new `InsecureReceiver` instance configured by 'uri' in the form of:
 //
-// 	insecure://
+//	insecure://
 func NewInsecureReceiver(ctx context.Context, uri string) (webhookd.WebhookReceiver, error) {
 
 	wh := InsecureReceiver{}

--- a/transformation/chicken.go
+++ b/transformation/chicken.go
@@ -28,7 +28,7 @@ type ChickenTransformation struct {
 
 // NewInsecureTransformation returns a new `ChickenTransformation` instance configured by 'uri' in the form of:
 //
-// 	chicken://{LANGUAGE_TAG}?{PARAMETERS}
+//	chicken://{LANGUAGE_TAG}?{PARAMETERS}
 //
 // Where {LANGUAGE_TAG} is any valid language tag supported by the `aaronland/go-chicken` package. Valid {PARAMETERS} are:
 // * `clucking={BOOLEAN}` A boolean flag to indicate whether messages should be transformed in the form of chicken noises.

--- a/transformation/null.go
+++ b/transformation/null.go
@@ -23,7 +23,7 @@ type NullTransformation struct {
 
 // NewInsecureTransformation returns a new `NullTransformation` instance configured by 'uri' in the form of:
 //
-// 	null://
+//	null://
 func NewNullTransformation(ctx context.Context, uri string) (webhookd.WebhookTransformation, error) {
 
 	p := NullTransformation{}

--- a/webhookd.go
+++ b/webhookd.go
@@ -24,13 +24,13 @@ type WebhookReceiver interface {
 	Receive(context.Context, *http.Request) ([]byte, *WebhookError)
 }
 
-//WebhookTransformation is an interface that defines methods for altering (transforming) the body of a (webhook) message after receipt.
+// WebhookTransformation is an interface that defines methods for altering (transforming) the body of a (webhook) message after receipt.
 type WebhookTransformation interface {
 	// Transforms() alters the body of a (webhook) message (according to rules defined by the package implementing the `WebhookTransformation` interface).
 	Transform(context.Context, []byte) ([]byte, *WebhookError)
 }
 
-//WebhookDispatcher is an interface that defines methods for relaying the body of a (webhook) message after it has been transformed.
+// WebhookDispatcher is an interface that defines methods for relaying the body of a (webhook) message after it has been transformed.
 type WebhookDispatcher interface {
 	// Dispatch() relays the body of a message (according to rules defined defined by the package implementing the `WebhookDispatcher` interface).
 	Dispatch(context.Context, []byte) *WebhookError


### PR DESCRIPTION
This release introduces the `webhookd.HaltEvent` error code which is treated as a non-fatal error that halts webhook processing immediately.